### PR TITLE
added -std=gnu99 to the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 MULTICALL = 1
-CFLAGS    = -Os -g -Wall -W
+CFLAGS    = -Os -g -Wall -W -std=gnu99
 PREFIX    = /usr/local
 RST2MAN   = rst2man
 RM        = rm -f


### PR DESCRIPTION
V3 repo has a problem with not having `-std=gnu99` in the build of dmon repo.